### PR TITLE
Explicitly include receipes after go parameters definition

### DIFF
--- a/vagrant/chef/cookbooks/dhcplb/recipes/default.rb
+++ b/vagrant/chef/cookbooks/dhcplb/recipes/default.rb
@@ -1,6 +1,9 @@
 node.default['go']['version'] = '1.6'
 node.default['go']['packages'] = ['github.com/facebookincubator/dhcplb']
 
+include_recipe 'golang'
+include_recipe 'golang::packages'
+
 directory '/home/vagrant/go' do
   owner 'vagrant'
   group 'vagrant'


### PR DESCRIPTION
For some reason it didn't work for me unless I explicitly included go recipes in dhcplb cookbook recipe. Chef was trying to launch dhcplp before even go was installed in system, not mentioning compiling the
project.

After applying this patch everything works as expected, `vagrant up` finishes successfully. 

`root      7760  0.0  0.8 131268  4168 ?        Ssl  09:42   0:00 /opt/go/bin/dhcplb -version 4 -config /home/vagrant/dhcplb.config.json`