### PR TITLE
Updated IsNetboot syntax as per dependency change

### DIFF
--- a/lib/handler.go
+++ b/lib/handler.go
@@ -344,7 +344,7 @@ func (s *serverImpl) handleRawPacketV6(buffer []byte, peer *net.UDPAddr) {
 		}
 	}
 	message.Mac = mac
-	message.NetBoot = dhcpv6.IsNetboot(msg)
+	message.NetBoot = msg.(*dhcpv6.DHCPv6Message).IsNetboot()
 
 	server, err := selectDestinationServer(s.config, &message)
 	if err != nil {


### PR DESCRIPTION
In https://github.com/insomniacslk/dhcp/pull/122 we moved `IsNetboot` to be a method of `DHCPv6Message`. This patch reflects that change here