### PR TITLE
Support for Lint test via Github Workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+name: Lint
+
+on:
+  push:
+
+jobs:
+  lint:
+    name: Lint Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          stable: 'false'
+          go-version: '1.15.4'
+      - name: Convert to modules
+        run: go mod init github.com/facebookincubator/dhcplb
+        
+      - name: Fetch Dependencies
+        run: go get -v ./...
+        
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: latest
+          skip-go-installation: true
+          args: --timeout 300s

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,6 @@ jobs:
           go-version: '1.15.4'
       - name: Convert to modules
         run: go mod init github.com/facebookincubator/dhcplb
-        
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,9 +16,6 @@ jobs:
       - name: Convert to modules
         run: go mod init github.com/facebookincubator/dhcplb
         
-      - name: Fetch Dependencies
-        run: go get -v ./...
-        
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:


### PR DESCRIPTION
* This PR adds support for running a lint test via Github Workflows. 

Issues found by the lint test as seen here: https://github.com/gaby/dhcplb/actions/runs/1361966961

```
Error: Error return value of `.Set` is not checked (errcheck)
Error: S1005: unnecessary assignment to the blank identifier (gosimple)
Error: S1000: should use for range instead of for { select {} } (gosimple)
Error: Error return value of `s.logger.LogErr` is not checked (errcheck)
Error: Error return value of `s.logger.LogErr` is not checked (errcheck)
Error: Error return value of `s.logger.LogErr` is not checked (errcheck)
Error: Error return value of `s.sendToServer` is not checked (errcheck)
Error: Error return value of `s.conn.WriteTo` is not checked (errcheck)
Error: Error return value of `s.sendToServer` is not checked (errcheck)
Error: Error return value of `conn.Write` is not checked (errcheck)
Error: Error return value of `s.conn.WriteTo` is not checked (errcheck)
Error: Error return value of `subject.UpdateStableServerList` is not checked (errcheck)
Error: Error return value of `subject.UpdateStableServerList` is not checked (errcheck)
Error: Error return value of `config.Algorithm.UpdateStableServerList` is not checked (errcheck)
Error: Error return value of `config.Algorithm.UpdateRCServerList` is not checked (errcheck)
Error: Error return value of `throttle.OK` is not checked (errcheck)
Error: type `id` is unused (unused)
Error: func `(*DHCPMessage).id` is unused (unused)
Error: S1003: should use strings.Contains(sourcerInfo[1], ",") instead (gosimple)
Error: S1023: redundant `return` statement (gosimple)
Error: S1023: redundant `return` statement (gosimple)
Error: S1023: redundant `return` statement (gosimple)
Error: ineffectual assignment to err (ineffassign)
Error: ineffectual assignment to err (ineffassign)
Error: ineffectual assignment to err (ineffassign)
Error: SA6002: argument should be pointer-like to avoid allocations (staticcheck)
Error: SA6002: argument should be pointer-like to avoid allocations (staticcheck)
```

Should these be fixed in a separate PR? 