### PR TITLE
fix lint: remove sync pool

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,4 +21,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           # TODO: fix lint
-          args: -D errcheck -D staticcheck
+          args: -D errcheck

--- a/lib/server.go
+++ b/lib/server.go
@@ -9,7 +9,6 @@ package dhcplb
 
 import (
 	"net"
-	"sync"
 	"sync/atomic"
 	"unsafe"
 
@@ -24,7 +23,6 @@ type Server struct {
 	config        *Config
 	stableServers []*DHCPServer
 	rcServers     []*DHCPServer
-	bufPool       sync.Pool
 	throttle      *Throttle
 }
 
@@ -82,13 +80,6 @@ func NewServer(config *Config, serverMode bool, personalizedLogger PersonalizedL
 		conn:   conn,
 		logger: loggerHelper,
 		config: config,
-	}
-
-	// pool to reuse packet buffers
-	server.bufPool = sync.Pool{
-		New: func() interface{} {
-			return make([]byte, server.GetConfig().PacketBufSize)
-		},
 	}
 
 	glog.Infof("Setting up throttle: Cache Size: %d - Cache Rate: %d - Request Rate: %d",


### PR DESCRIPTION
Lint warns about extra allocations being done due to the way `sync.Pool` is being used:
https://deepsource.io/gh/beego/beego/issue/SCC-SA6002/occurrences

I don't think we need `sync.Pool` at all. The public NTP infra doesn't do this and it is scaling well:
https://github.com/facebook/time/blob/main/ntp/responder/server/server.go#L160