### PR TITLE
simplify logHelper

### DIFF
--- a/lib/handler.go
+++ b/lib/handler.go
@@ -162,10 +162,7 @@ func (s *Server) sendToServer(start time.Time, server *DHCPServer, packet []byte
 		return err
 	}
 
-	err = s.logger.LogSuccess(start, server, packet, peer)
-	if err != nil {
-		glog.Errorf("Failed to log request: %s", err)
-	}
+	s.logger.LogSuccess(start, server, packet, peer)
 
 	return nil
 }
@@ -210,10 +207,7 @@ func (s *Server) handleRawPacketV4(buffer []byte, peer *net.UDPAddr) {
 
 func (s *Server) handleV4Server(start time.Time, packet *dhcpv4.DHCPv4, peer *net.UDPAddr) {
 	reply, err := s.config.Handler.ServeDHCPv4(packet)
-	logErr := s.logger.LogSuccess(start, nil, packet.ToBytes(), peer)
-	if logErr != nil {
-		glog.Errorf("Failed to log incoming packet: %s", logErr)
-	}
+	s.logger.LogSuccess(start, nil, packet.ToBytes(), peer)
 	if err != nil {
 		glog.Errorf("Error creating reply %s", err)
 		s.logger.LogErr(start, nil, packet.ToBytes(), peer, fmt.Sprintf("%T", err), err)
@@ -224,10 +218,7 @@ func (s *Server) handleV4Server(start time.Time, packet *dhcpv4.DHCPv4, peer *ne
 		Port: dhcpv4.ServerPort,
 	}
 	s.conn.WriteTo(reply.ToBytes(), addr)
-	err = s.logger.LogSuccess(start, nil, reply.ToBytes(), peer)
-	if err != nil {
-		glog.Errorf("Failed to log reply: %s", err)
-	}
+	s.logger.LogSuccess(start, nil, reply.ToBytes(), peer)
 }
 
 func (s *Server) handleRawPacketV6(buffer []byte, peer *net.UDPAddr) {
@@ -316,19 +307,13 @@ func (s *Server) handleV6RelayRepl(start time.Time, packet dhcpv6.DHCPv6, peer *
 		return
 	}
 	conn.Write(msg.ToBytes())
-	err = s.logger.LogSuccess(start, nil, packet.ToBytes(), peer)
-	if err != nil {
-		glog.Errorf("Failed to log request: %s", err)
-	}
+	s.logger.LogSuccess(start, nil, packet.ToBytes(), peer)
 	conn.Close()
 }
 
 func (s *Server) handleV6Server(start time.Time, packet dhcpv6.DHCPv6, peer *net.UDPAddr) {
 	reply, err := s.config.Handler.ServeDHCPv6(packet)
-	logErr := s.logger.LogSuccess(start, nil, packet.ToBytes(), peer)
-	if logErr != nil {
-		glog.Errorf("Failed to log incoming packet: %s", logErr)
-	}
+	s.logger.LogSuccess(start, nil, packet.ToBytes(), peer)
 	if err != nil {
 		glog.Errorf("Error creating reply %s", err)
 		s.logger.LogErr(start, nil, packet.ToBytes(), peer, fmt.Sprintf("%T", err), err)
@@ -339,8 +324,5 @@ func (s *Server) handleV6Server(start time.Time, packet dhcpv6.DHCPv6, peer *net
 		Port: dhcpv6.DefaultServerPort,
 	}
 	s.conn.WriteTo(reply.ToBytes(), addr)
-	err = s.logger.LogSuccess(start, nil, reply.ToBytes(), peer)
-	if err != nil {
-		glog.Errorf("Failed to log reply: %s", err)
-	}
+	s.logger.LogSuccess(start, nil, reply.ToBytes(), peer)
 }

--- a/lib/log.go
+++ b/lib/log.go
@@ -32,19 +32,13 @@ type PersonalizedLogger interface {
 	Log(msg LogMessage) error
 }
 
-// LoggerHelper is an interface used to log.
-type loggerHelper interface {
-	LogErr(start time.Time, server *DHCPServer, packet []byte, peer *net.UDPAddr, errName string, err error) error
-	LogSuccess(start time.Time, server *DHCPServer, packet []byte, peer *net.UDPAddr) error
-}
-
-// loggerHelperImpl is the implementation of the above interface.
-type loggerHelperImpl struct {
+// loggerHelper is the implementation of the above interface.
+type loggerHelper struct {
 	personalizedLogger PersonalizedLogger
 	version            int
 }
 
-func (h *loggerHelperImpl) LogErr(start time.Time, server *DHCPServer, packet []byte, peer *net.UDPAddr, errName string, err error) error {
+func (h *loggerHelper) LogErr(start time.Time, server *DHCPServer, packet []byte, peer *net.UDPAddr, errName string, err error) {
 	if h.personalizedLogger != nil {
 		hostname := ""
 		isRC := false
@@ -66,13 +60,11 @@ func (h *loggerHelperImpl) LogErr(start time.Time, server *DHCPServer, packet []
 		err := h.personalizedLogger.Log(msg)
 		if err != nil {
 			glog.Errorf("Failed to log error: %s", err)
-			return err
 		}
 	}
-	return nil
 }
 
-func (h *loggerHelperImpl) LogSuccess(start time.Time, server *DHCPServer, packet []byte, peer *net.UDPAddr) error {
+func (h *loggerHelper) LogSuccess(start time.Time, server *DHCPServer, packet []byte, peer *net.UDPAddr) {
 	if h.personalizedLogger != nil {
 		hostname := ""
 		isRC := false
@@ -92,8 +84,6 @@ func (h *loggerHelperImpl) LogSuccess(start time.Time, server *DHCPServer, packe
 		err := h.personalizedLogger.Log(msg)
 		if err != nil {
 			glog.Errorf("Failed to log error: %s", err)
-			return err
 		}
 	}
-	return nil
 }

--- a/lib/server.go
+++ b/lib/server.go
@@ -19,7 +19,7 @@ import (
 type Server struct {
 	server        bool
 	conn          *net.UDPConn
-	logger        loggerHelper
+	logger        *loggerHelper
 	config        *Config
 	stableServers []*DHCPServer
 	rcServers     []*DHCPServer
@@ -70,7 +70,7 @@ func NewServer(config *Config, serverMode bool, personalizedLogger PersonalizedL
 	}
 
 	// setup logger
-	var loggerHelper = &loggerHelperImpl{
+	var loggerHelper = &loggerHelper{
 		version:            config.Version,
 		personalizedLogger: personalizedLogger,
 	}


### PR DESCRIPTION
* lint complains that in some places the return value of `LogErr` is not checked
* remove the error return. Most logger implementations do not return an error. E.g.
  * https://github.com/insomniacslk/dhcp/blob/master/dhcpv6/server6/logger.go#L8
* remove the `loggerHelper` interface as there has never been a way to use a different one